### PR TITLE
Add configurable defect options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,25 @@ be installed separately and available in your environment.
 ```bash
 defect-tool run-defect --top path/to/system.gro \
                       --traj path/to/trajectory.xtc \
-                      --output-dir results/defects
+                      --output-dir results/defects \
+                      --radii-file path/to/radii.json \
+                      --defect-config path/to/defects.json
 ```
+
+### Defect configuration file
+
+The JSON file supplied to `--defect-config` should contain a mapping of defect
+names to integer threshold values:
+
+```json
+{
+  "PLacyl": 1,
+  "TGglyc": 2,
+  "TGacyl": 3
+}
+```
+
+When not provided, these defaults are used automatically.
 
 ### Run radius analysis
 

--- a/defect/cli.py
+++ b/defect/cli.py
@@ -10,8 +10,14 @@ def cli():
 @click.option('--top', required=True, help="Topology file (.gro)")
 @click.option('--traj', required=True, help="Trajectory file (.xtc/.dcd)")
 @click.option('--output-dir', default='output', help="Output directory")
-def run_defect_cmd(top, traj, output_dir):
-    run_defect(top, traj, output_dir)
+@click.option('--radii-file', default='defect/types_radii.json',
+              help='JSON file with atom type radii')
+@click.option('--defect-config', default=None,
+              help='JSON file mapping defect names to thresholds')
+def run_defect_cmd(top, traj, output_dir, radii_file, defect_config):
+    run_defect(top, traj, output_dir,
+               radii_file=radii_file,
+               defect_config=defect_config)
 
 @cli.command()
 @click.option('--base-directory', required=True, help="Input GRO directory")

--- a/defect/defects2.py
+++ b/defect/defects2.py
@@ -64,7 +64,8 @@ class PackingDefect2:
 
 
 class PackingDefect2Sequential:
-    def __init__(self, atomgroups, radii, prefix='./', leaflet='both', defect_types=None, defect_thresholds=None):
+    def __init__(self, atomgroups, radii, prefix='./', leaflet='both',
+                 defect_types=None, defect_thresholds=None):
         self.N = 10000 
         self.universe = atomgroups[0].universe
         self.dt = self.universe.trajectory[0].dt 
@@ -78,8 +79,16 @@ class PackingDefect2Sequential:
         self.bbox_data = {"x_min": 0, "x_max": 0, "y_min": 0, "y_max": 0} 
         self._results = []
 
+        if defect_types is None and defect_thresholds is not None:
+            defect_types = list(defect_thresholds.keys())
+
         self.defect_types = defect_types or ['PLacyl', 'TGglyc', 'TGacyl']
-        self.defect_thresholds = defect_thresholds or {t: i + 1 for i, t in enumerate(self.defect_types)}
+
+        if defect_thresholds is None:
+            self.defect_thresholds = {t: i + 1 for i, t in enumerate(self.defect_types)}
+        else:
+            self.defect_thresholds = defect_thresholds
+
         validate_defect_thresholds(self.defect_types, self.defect_thresholds)
 
     def process(self):

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -11,9 +11,15 @@ def cli():
 @click.option('--top', required=True, help="Topology file (.gro)")
 @click.option('--traj', required=True, help="Trajectory file (.xtc/.dcd)")
 @click.option('--output-dir', default='output', help="Output directory")
-def run_defect_cmd(top, traj, output_dir):
+@click.option('--radii-file', default='defect/types_radii.json',
+              help='JSON file with atom type radii')
+@click.option('--defect-config', default=None,
+              help='JSON file mapping defect names to thresholds')
+def run_defect_cmd(top, traj, output_dir, radii_file, defect_config):
     """Run packing defect extraction"""
-    run_defect(top, traj, output_dir)
+    run_defect(top, traj, output_dir,
+               radii_file=radii_file,
+               defect_config=defect_config)
 
 @cli.command(name='run-radius')
 @click.option('--base-directory', required=True, help="Input GRO directory")

--- a/scripts/run_defect.py
+++ b/scripts/run_defect.py
@@ -1,10 +1,31 @@
 # scripts/run_defect.py
 import os
+import json
 import MDAnalysis as mda
 from defect import defects2
 
-def run_defect(top_file, traj_file, output_dir):
-    radii_file = 'defect/types_radii.json'
+def run_defect(top_file, traj_file, output_dir,
+               radii_file='defect/types_radii.json',
+               defect_config=None):
+    """Run packing defect extraction.
+
+    Parameters
+    ----------
+    top_file : str
+        Path to the system topology (.gro).
+    traj_file : str
+        Path to the trajectory (.xtc/.dcd).
+    output_dir : str
+        Directory where output GRO files will be written.
+    radii_file : str, optional
+        JSON file mapping atom types to radii. Defaults to
+        ``defect/types_radii.json``.
+    defect_config : str, optional
+        JSON file mapping defect names to integer thresholds. If
+        provided, these values will be forwarded to
+        :class:`PackingDefect2Sequential`.
+    """
+
     pd = defects2.PackingDefect2(radii_file)
 
     lipid = 'top/top_all36_lipid.rtf'
@@ -25,5 +46,18 @@ def run_defect(top_file, traj_file, output_dir):
     MEMB = u.select_atoms('resname POPC DOPE SAPI TRIO CHYO')
 
     os.makedirs(output_dir, exist_ok=True)
-    pdPMDA = defects2.PackingDefect2Sequential([MEMB], radii, prefix=output_dir, leaflet='both')
+    defect_types = None
+    defect_thresholds = None
+    if defect_config:
+        with open(defect_config) as f:
+            defect_thresholds = json.load(f)
+        defect_types = list(defect_thresholds.keys())
+
+    pdPMDA = defects2.PackingDefect2Sequential(
+        [MEMB], radii,
+        prefix=output_dir,
+        leaflet='both',
+        defect_types=defect_types,
+        defect_thresholds=defect_thresholds
+    )
     pdPMDA.process()


### PR DESCRIPTION
## Summary
- extend `run_defect` to load custom radii and defect mapping JSON files
- expose `--radii-file` and `--defect-config` options in CLI entry points
- allow `PackingDefect2Sequential` to accept caller-provided defect types and thresholds
- document JSON format and CLI usage in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ae1a5e9348332be210d882567af6e